### PR TITLE
Support fetching messages from MH based on an old timestamp

### DIFF
--- a/iot4i-v2/iot4i-shield-toolkit/com.ibm.iot4i.events.MH/Source.spl
+++ b/iot4i-v2/iot4i-shield-toolkit/com.ibm.iot4i.events.MH/Source.spl
@@ -13,6 +13,7 @@ public composite Source(output stream<rstring key, rstring message>
 		expression<rstring> $TOPIC ;
 		expression<rstring> $GROUP_ID ;
 		expression<rstring> $CLIENT_ID ;
+		expression<int64> $START_TIME : 0l ;
 		expression<rstring> $SECURITY_PROTOCOL : "SASL_SSL" ;
 		expression<rstring> $SASL_MECHANISM : "PLAIN" ;
 		expression<rstring> $SSL_PROTOCOL : "TLSv1.2" ;
@@ -22,8 +23,16 @@ public composite Source(output stream<rstring key, rstring message>
 	graph
 		stream<rstring key, rstring message> SourceStream = KafkaConsumer()
 		{
+			logic
+				state :
+				{
+					int64 _startTime =($START_TIME == 0l) ? getTimestampInMs() : $START_TIME ;
+				}
+
 			param
 				topic : $TOPIC ;
+				startPosition : Time ;
+				startTime : _startTime ;
 				propertiesFile : getKafkaPropertiesFileName(getThisToolkitDir(),
 					$KAFKA_BROKERS_SASL, $USERNAME, $PASSWORD, $GROUP_ID, $CLIENT_ID,
 					$SECURITY_PROTOCOL, $SASL_MECHANISM, $SSL_PROTOCOL,

--- a/iot4i-v2/iot4i-shield-toolkit/impl/java/src/com/ibm/iot4i/events/MH/GetTimestampInMsImpl.java
+++ b/iot4i-v2/iot4i-shield-toolkit/impl/java/src/com/ibm/iot4i/events/MH/GetTimestampInMsImpl.java
@@ -1,0 +1,13 @@
+package com.ibm.iot4i.events.MH;
+
+
+import com.ibm.streams.function.model.Function;
+
+public class GetTimestampInMsImpl  {
+
+    @Function(namespace="com.ibm.iot4i.events.MH", name="getTimestampInMs", description="", stateful=false)
+    public static long getTimestampInMs() {
+   	    return System.currentTimeMillis();
+    }
+    
+}

--- a/iot4i-v2/iot4i-shield-toolkit/info.xml
+++ b/iot4i-v2/iot4i-shield-toolkit/info.xml
@@ -12,12 +12,12 @@
       <common:version>2.1.0</common:version>
     </info:toolkit>
     <info:toolkit>
-      <common:name>com.ibm.streamsx.kafka</common:name>
-      <common:version>[1.0.0,2.0.0)</common:version>
-    </info:toolkit>
-    <info:toolkit>
       <common:name>com.ibm.streamsx.messaging</common:name>
       <common:version>[5.3.0,6.0.0)</common:version>
+    </info:toolkit>
+    <info:toolkit>
+      <common:name>com.ibm.streamsx.kafka</common:name>
+      <common:version>[1.2.2,2.0.0)</common:version>
     </info:toolkit>
   </info:dependencies>
 </info:toolkitInfoModel>

--- a/iot4i-v2/iot4i-shield-toolkit/toolkit.xml
+++ b/iot4i-v2/iot4i-shield-toolkit/toolkit.xml
@@ -141,6 +141,7 @@
         <parameter metaType="Expression" name="TOPIC" optional="false" type="&lt;rstring>"/>
         <parameter metaType="Expression" name="GROUP_ID" optional="false" type="&lt;rstring>"/>
         <parameter metaType="Expression" name="CLIENT_ID" optional="false" type="&lt;rstring>"/>
+        <parameter defaultValue="0l" metaType="Expression" name="START_TIME" optional="true" type="&lt;int64>"/>
         <parameter defaultValue="&quot;SASL_SSL&quot;" metaType="Expression" name="SECURITY_PROTOCOL" optional="true" type="&lt;rstring>"/>
         <parameter defaultValue="&quot;PLAIN&quot;" metaType="Expression" name="SASL_MECHANISM" optional="true" type="&lt;rstring>"/>
         <parameter defaultValue="&quot;TLSv1.2&quot;" metaType="Expression" name="SSL_PROTOCOL" optional="true" type="&lt;rstring>"/>
@@ -149,6 +150,9 @@
         <parameter defaultValue="&quot;HTTPS&quot;" metaType="Expression" name="SSL_ENDPOINT_IDENTIFICATION_ALGORITHM" optional="true" type="&lt;rstring>"/>
         <outputPort name="SourceStream" portIndex="0" type="stream&lt;rstring key, rstring message>"/>
       </compositeOp>
+      <function modelUriIndex="15" name="getTimestampInMs" native="true" public="true" returnType="int64" uriIndex="0">
+        <prototype>public int64 getTimestampInMs()</prototype>
+      </function>
       <function modelUriIndex="15" name="getUserId" native="true" public="true" returnType="T" uriIndex="0">
         <prototype>&lt;string T&gt; public T getUserId(T message)</prototype>
         <parameter name="message" type="T"/>
@@ -223,12 +227,12 @@ Specifies command-line arguments that are passed to the Java virtual machine tha
       <common:version>2.1.0</common:version>
     </dependency>
     <dependency>
-      <common:name>com.ibm.streamsx.kafka</common:name>
-      <common:version>[1.0.0,2.0.0)</common:version>
-    </dependency>
-    <dependency>
       <common:name>com.ibm.streamsx.messaging</common:name>
       <common:version>[5.3.0,6.0.0)</common:version>
+    </dependency>
+    <dependency>
+      <common:name>com.ibm.streamsx.kafka</common:name>
+      <common:version>[1.2.2,2.0.0)</common:version>
     </dependency>
     <sabFiles>
       <ti:include path="toolkit.xml" root="toolkitDir"/>


### PR DESCRIPTION
- Used latest version (v1.2.2) of [kafka toolkit](https://github.com/IBMStreams/streamsx.kafka/releases) 
- Add optional parameter START_TIME which defaults to now
- If parameter is set, the kafka source will start from that time.